### PR TITLE
test: Fix resign.bats

### DIFF
--- a/test/resign.bats
+++ b/test/resign.bats
@@ -28,10 +28,15 @@ load test_helper
   assert_failure
 }
 
-# This doesn't work on Travis CI
-#@test "relax resign with invalid keychain" {
-#  rm -rf *-resigned.ipa
-#  run relax resign -i "com.scenee.SampleApp" -p "Relax AdHoc" -c "iPhone Distribution: Shin Yamamoto (J3D7L9FHSS)" "$(relax show development ipa)"
-#  echo "$output" >> bats.log
-#  assert_failure
-#}
+@test "relax resign with invalid keychain" {
+
+  relax keychain reset
+
+  rm -rf *-resigned.ipa
+  run relax resign -k System.keychain -i "com.scenee.SampleApp" -p "Relax AdHoc" -c "iPhone Distribution: Shin Yamamoto (J3D7L9FHSS)" "$(relax show development ipa)"
+  echo "$output" >> bats.log
+  assert_failure
+
+  relax keychain use relax.keychain -p relax
+
+}


### PR DESCRIPTION
Fix `test/resign.bats` to make it work well on Travis CI(equal to macOS Sierra).