### PR TITLE
Export use application properties in archive

### DIFF
--- a/libexec/relax
+++ b/libexec/relax
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash -eu
 # Usage: relax [--version] [--config <Relfile>] <command>
 
-export VERSION="0.3.1"
+export REL_VERSION="0.3.1"
 
 ###################
 ### Environment ###

--- a/libexec/relax---version
+++ b/libexec/relax---version
@@ -18,4 +18,4 @@ if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q rel
 	git_revision="${git_revision#v}"
 fi
 
-echo "relax ${git_revision:-$VERSION}"
+echo "relax ${git_revision:-$REL_VERSION}"

--- a/libexec/relax-export
+++ b/libexec/relax-export
@@ -198,8 +198,9 @@ if [[ -z "$target_archive_file" ]]; then
 fi
 
 
+
 trap 'teardown_build' EXIT INT TERM
-setup_build $release
+setup_build --export "$target_archive_file" $release
 prepare_export
 
 export_archive "$target_archive_file"

--- a/libexec/util
+++ b/libexec/util
@@ -66,66 +66,6 @@ print_commands () {
 }
 
 
-# print_progress_time <pid>
-print_progress_time () {
-	local pid=$1
-	local delay=0.16666666 # 0.016666666 * 10
-	local stime=$(date "+%s")
-	local i=1
-
-	# For a interrupt timing issue
-	trap "stty echo; tput cnorm; " INT TERM
-
-	star="$BOLD"'\xE2\x88\x97'"$NC"
-	lbr="$BLUE[$NC"
-	rbr="$BLUE]$NC"
-	sp=("$lbr$star  $rbr"  "$lbr $star $rbr"  "$lbr  $star$rbr"  "$lbr $star $rbr")
-
-	# Invisible cursor.
-	tput civis
-	# Don't echo back any chars typed.
-	stty -echo
-
-	while ps -p $pid | grep -q $pid; do
-		now=$(date "+%s")
-		dt=$(date -r "$(( $now - $stime ))" "+%s")
-		printf "\b${sp[i++%${#sp[*]}]} Time: ${dt}s\r"
-		sleep $delay
-	done
-
-	tput el # Clear to end of line
-	printf "Time: ${dt}s\n"
-
-	# Retore tty and tput
-	stty echo
-	tput cnorm
-
-	if wait $pid; then
-		return 0
-	else
-		return 1
-	fi
-}
-
-# progress_bar <pid>
-progress_bar()
-{
-	local pid=$1
-	local delay=0.75
-	printf "["
-	while ps -p $pid | grep -q $pid; do
-		printf  "▓"
-		sleep $delay
-	done
-	if wait $pid; then
-		printf "] done!\n"
-		return 0
-	else
-		printf "]\n"
-		return 1
-	fi
-}
-
 compare_versions()
 {
     local v1=( $(echo "$1" | tr '.' ' ') )
@@ -261,7 +201,6 @@ logi () {
 
 
 declare -x -f print_commands print_completions
-declare -x -f print_progress_time progress_bar
 declare -x -f check_toolchain compare_versions 
 declare -x -f fin die die_with_status
 declare -x -f logi logv logd __log

--- a/libexec/util-build
+++ b/libexec/util-build
@@ -75,6 +75,68 @@ dec_provisioning_profile () {
 	set -e
 }
 
+# print_progress_time <pid>
+print_progress_time () {
+	local pid=$1
+	local delay=0.16666666 # 0.016666666 * 10
+	local stime=$(date "+%s")
+	local i=1
+
+	# For a interrupt timing issue
+	trap "__kill_bg_xcodebuid_task $XCODEBUILD_PID; \
+		stty echo; tput cnorm; " INT TERM
+
+	star="$BOLD"'\xE2\x88\x97'"$NC"
+	lbr="$BLUE[$NC"
+	rbr="$BLUE]$NC"
+	sp=("$lbr$star  $rbr"  "$lbr $star $rbr"  "$lbr  $star$rbr"  "$lbr $star $rbr")
+
+	# Invisible cursor.
+	tput civis
+	# Don't echo back any chars typed.
+	stty -echo
+
+	while ps -p $pid | grep -q $pid; do
+		now=$(date "+%s")
+		dt=$(date -r "$(( $now - $stime ))" "+%s")
+		printf "\b${sp[i++%${#sp[*]}]} Time: ${dt}s\r"
+		sleep $delay
+	done
+
+	tput el # Clear to end of line
+	printf "Time: ${dt}s\n"
+
+	# Retore tty and tput
+	stty echo
+	tput cnorm
+
+	if wait $pid; then
+		return 0
+	else
+		return 1
+	fi
+}
+
+# progress_bar <pid>
+progress_bar()
+{
+	local pid=$1
+	local delay=0.75
+	printf "["
+	while ps -p $pid | grep -q $pid; do
+		printf  "▓"
+		sleep $delay
+	done
+	if wait $pid; then
+		printf "] done!\n"
+		return 0
+	else
+		printf "]\n"
+		return 1
+	fi
+}
+
+
 __kill_bg_xcodebuid_task () {
 	if [[ -n ${XCODEBUILD_PID} ]]; then
 		if ps -p $XCODEBUILD_PID > /dev/null; then
@@ -594,6 +656,7 @@ update_archived_entitlements_xcent () {
 	cp "$_entitlements_xcent" "$app_path/$ARCHIVED_ENTITLEMENTS_XCENT"
 }
 
+declare -x -f print_progress_time progress_bar
 declare -x -f __kill_bg_xcodebuid_task
 declare -x -f __check_scheme __map_vals __replace_development_team
 declare -x -f load_xcode_build_settings get_build_params_file

--- a/libexec/util-build
+++ b/libexec/util-build
@@ -83,8 +83,8 @@ print_progress_time () {
 	local i=1
 
 	# For a interrupt timing issue
-	trap "__kill_bg_xcodebuid_task $XCODEBUILD_PID; \
-		stty echo; tput cnorm; " INT TERM
+	trap "stty echo; tput cnorm;  \
+		__kill_bg_xcodebuid_task $XCODEBUILD_PID;" INT TERM
 
 	star="$BOLD"'\xE2\x88\x97'"$NC"
 	lbr="$BLUE[$NC"
@@ -191,6 +191,8 @@ __map_vals () {
 		build_settings=( $(eval echo '$'{REL_CONFIG_${release}_build_settings[@]} ) )
 	test -z $bundle_identifier && \
 		bundle_identifier=$(eval echo '$'REL_CONFIG_${release}_bundle_identifier)
+	test -z $version && \
+		version=$(eval echo '$'REL_CONFIG_${release}_version)
 	test -z $bundle_version && \
 		bundle_version=$(eval echo '$'REL_CONFIG_${release}_bundle_version)
 	test -z $team_id && \
@@ -441,8 +443,20 @@ teardown_build () {
 	fi
 }
 
-# prepare_build <release>
+# setup_build [--export <archive-path>] <release>
 setup_build () {
+	local for_export=false
+	local archived_info_plist version
+
+	case "$1" in
+	--export) 
+		for_export=true
+		shift
+		archived_info_plist="$1"/Info.plist
+		shift
+		;;
+	esac
+
 	if test ! -d $REL_TEMP_DIR; then
 		die "Not found Temporary directory"
 	fi
@@ -491,7 +505,7 @@ setup_build () {
 	logi "Configuration: $CONFIGURATION"
 	configuration=$CONFIGURATION
 
-	INFO_PLIST_PATH=$PRODUCT_SETTINGS_PATH
+	INFO_PLIST_PATH="$PRODUCT_SETTINGS_PATH"
 
 	# StaticLibrary doesn't have a Info.plist
 	if [ -z $INFO_PLIST_PATH ]; then
@@ -501,8 +515,8 @@ setup_build () {
 		return
 	fi
 
-	cp $INFO_PLIST_PATH $INFO_PLIST_PATH.$BAK_EXT
-	logd "Info plist: $INFO_PLIST_PATH"
+	cp "$INFO_PLIST_PATH" "$INFO_PLIST_PATH.$BAK_EXT"
+	logv "Info plist: $INFO_PLIST_PATH"
 
 	set +e
 	$LIBEXEC_DIR/update_info_plist.rb "$REL_CONFIG_PATH" "$release" "$INFO_PLIST_PATH" >/dev/null 2>"${stdtemp}"
@@ -524,6 +538,8 @@ setup_build () {
 		"$PROJECT_FILE_PATH"/project.pbxproj
 		/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $bundle_identifier" "$INFO_PLIST_PATH"
 		PRODUCT_BUNDLE_IDENTIFIER=$bundle_identifier
+	elif [[ $for_export == true ]]; then
+		PRODUCT_BUNDLE_IDENTIFIER="$(/usr/libexec/PlistBuddy -c "Print :ApplicationProperties:CFBundleIdentifier" "$archived_info_plist")"
 	fi
 
 	## Support a xcode project file not including PRODUCT_BUNDLE_IDENTIFIER 
@@ -537,18 +553,22 @@ setup_build () {
 		fi
 	else # PRODUCT_BUNDLE_IDENTIFIER sometimes can be differenct from Info.plist
 
-		local info_plist_bundle_identifier=$(print_info_plist bundle_identifier "$INFO_PLIST_PATH")
-
-		# Should eval a CFBundleIdentifier value because it's can be $(PRODUCT_BUNDLE_IDENTIFIER)
-		if [[ "$info_plist_bundle_identifier" = "\$(PRODUCT_BUNDLE_IDENTIFIER)" ]]; then
+		if [[ $for_export == true ]]; then
 			:
 		else
-			if [[ ${PRODUCT_BUNDLE_IDENTIFIER} != "$info_plist_bundle_identifier" ]]; then
-				logi "$ERR PRODUCT_BUNDLE_IDENTIFIER($PRODUCT_BUNDLE_IDENTIFIER) setting is different from the value($info_plist_bundle_identifier) of CFBundleIdentifier in Info.plist."
-				die "$NOTE Please edit 'Product Bundle Identifier' in '$PRODUCT_NAME' > 'Build Settings' pane."
-			fi
+			local info_plist_bundle_identifier="$(print_info_plist bundle_identifier "$INFO_PLIST_PATH")";
 
-			PRODUCT_BUNDLE_IDENTIFIER=$info_plist_bundle_identifier
+			# Should eval a CFBundleIdentifier value because it's can be $(PRODUCT_BUNDLE_IDENTIFIER)
+			if [[ "$info_plist_bundle_identifier" = "\$(PRODUCT_BUNDLE_IDENTIFIER)" ]]; then
+				:
+			else
+				if [[ ${PRODUCT_BUNDLE_IDENTIFIER} != "$info_plist_bundle_identifier" ]]; then
+					logi "$ERR PRODUCT_BUNDLE_IDENTIFIER($PRODUCT_BUNDLE_IDENTIFIER) setting is different from the value($info_plist_bundle_identifier) of CFBundleIdentifier in Info.plist."
+					die "$NOTE Please edit 'Product Bundle Identifier' in '$PRODUCT_NAME' > 'Build Settings' pane."
+				fi
+
+				PRODUCT_BUNDLE_IDENTIFIER=$info_plist_bundle_identifier
+			fi
 		fi
 	fi
 
@@ -571,31 +591,44 @@ setup_build () {
 		logi "$ARROW Change ProvisioningStyle to Manual for \"$provisioning_profile\""
 	fi
 
-	## Bundle Version
-	local version=$(print_info_plist version "$INFO_PLIST_PATH")
-	local bundle=$(print_info_plist bundle_version "$INFO_PLIST_PATH")
-	local abbcommit=$(git log -1 --format='%h')
-	local branch=$(git symbolic-ref --short HEAD)
-	local config=$(echo $configuration | tr [:upper:] [:lower:])
-
-	if test "${bundle_version:-undefined}" = undefined; then
-		BUNDLE_VERSION=$(print_info_plist bundle_version "$INFO_PLIST_PATH")
+	if [[ ${version:-undefined} == undefined ]]; then
+		BUNDLE_SHORT_VERSION="$(print_info_plist version "$INFO_PLIST_PATH")"
 	else
-		BUNDLE_VERSION=$bundle_version
+		BUNDLE_SHORT_VERSION="$version"
 	fi
 
-	BUNDLE_VERSION=$(echo "$BUNDLE_VERSION" | awk '
-	{
-		gsub(/%V/, "'"$version"'");
-		gsub(/%B/, "'"$bundle"'");
-		gsub(/%C/, "'"$config"'");
-		gsub(/%h/, "'"$abbcommit"'");
-		gsub(/%D/, "'"${branch//\//_}"'");
-		print
-	}') # See [Semantic Versioning 2.0.0](http://semver.org)
 
+	if [[ $for_export == true && "${bundle_version:-undefined}" = undefined ]]; then
+		BUNDLE_VERSION="$(/usr/libexec/PlistBuddy -c "Print :ApplicationProperties:CFBundleVersion" "$archived_info_plist")"
+		BUNDLE_SHORT_VERSION="$(/usr/libexec/PlistBuddy -c "Print :ApplicationProperties:CFBundleShortVersionString" "$archived_info_plist")"
+	else
+		## Bundle Version
+		local bundle=$(print_info_plist bundle_version "$INFO_PLIST_PATH")
+		local abbcommit=$(git log -1 --format='%h')
+		local branch=$(git symbolic-ref --short HEAD)
+		local config=$(echo $configuration | tr [:upper:] [:lower:])
+
+		if test "${bundle_version:-undefined}" = undefined; then
+			BUNDLE_VERSION=$(print_info_plist bundle_version "$INFO_PLIST_PATH")
+		else
+			BUNDLE_VERSION=$bundle_version
+		fi
+
+		BUNDLE_VERSION=$(echo "$BUNDLE_VERSION" | awk '
+		{
+			gsub(/%V/, "'"$version"'");
+			gsub(/%B/, "'"$bundle"'");
+			gsub(/%C/, "'"$config"'");
+			gsub(/%h/, "'"$abbcommit"'");
+			gsub(/%D/, "'"${branch//\//_}"'");
+			print
+		}') # See [Semantic Versioning 2.0.0](http://semver.org)
+	fi
+
+	/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $BUNDLE_SHORT_VERSION" "$INFO_PLIST_PATH"
 	/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUNDLE_VERSION" "$INFO_PLIST_PATH"
 
+	logi "Version: $BUNDLE_SHORT_VERSION"
 	logi "Bundle Version: $BUNDLE_VERSION"
 
 	## Product Build Root
@@ -605,7 +638,7 @@ setup_build () {
 		if [[ $BUNDLE_VERSION =~ (.*)\$\(CURRENT_PROJECT_VERSION\)(.*) ]]; then
 			BUNDLE_VERSION="${BASH_REMATCH[1]}${CURRENT_PROJECT_VERSION}${BASH_REMATCH[2]}"
 		fi
-		if [[ ! $BUNDLE_VERSION =~ "$config" ]]; then
+		if [[ $for_export == false ]] && ! echo $BUNDLE_VERSION  | grep -iqF $configuration;  then
 			BUNDLE_VERSION=$BUNDLE_VERSION-$configuration
 		fi
 		PRODUCT_BUILD_ROOT=$(eval echo "$REL_RELEASE_ROOT/$release/$scheme-$BUNDLE_VERSION")

--- a/sample/SampleApp/Relfile
+++ b/sample/SampleApp/Relfile
@@ -10,6 +10,8 @@ development:
   configuration: Debug
   provisioning_profile: "$PROVISION_PROFILE_DEV" # You don't need to use the Environment variable. This's just for test.
   team_id: J3D7L9FHSS
+  bundle_identifier: com.scenee.SampleApp # Please replace your valid identifier.
+  bundle_version:  "%h-%C"
   build_settings:
     OTHER_SWIFT_FLAGS: 
       - "-DMOCK"
@@ -21,7 +23,6 @@ development:
     compileBitcode: false
   info_plist:
     CFBundleName: Sample (Debug)
-    CFBundleVersion: "%h-%C"
     CFBundleDevelopmentRegion: $COUNTRY
     UISupportedExternalAccessoryProtocols:
       - com.example.SampleApp
@@ -31,6 +32,8 @@ development2:
   scheme: Sample App
   bundle_identifier: com.scenee.SampleApp.$BUNDLE_SUFFIX
   configuration: Debug
+  version: "$VERSION"
+  bundle_version: "%h-debug-internal"
   provisioning_profile: "$PROVISION_PROFILE_DEV"
   export_options:
     method: development
@@ -38,8 +41,6 @@ development2:
 
 adhoc:
   scheme: Sample App
-  bundle_identifier: com.scenee.SampleApp # Please replace your valid identifier.
-  bundle_version:  "%h-%C"
   provisioning_profile: "$PROVISION_PROFILE_ADHOC"
   export_options:
     method: ad-hoc 

--- a/test/archive.bats
+++ b/test/archive.bats
@@ -5,14 +5,13 @@ load test_helper
 @test "relax archive development" {
   export COUNTRY=ja
   run relax archive development
-  echo "${output}" >> bats.log
   assert_success
 }
 
 @test "relax archive development2" {
   export BUNDLE_SUFFIX=debug
+  export VERSION="0.0.1"
   run  relax archive development2
-  echo "${output}" >> bats.log
   assert_success
 }
 

--- a/test/export.bats
+++ b/test/export.bats
@@ -9,9 +9,23 @@ load test_helper
 
 @test "relax export adhoc <development-archive>" {
   run relax export adhoc "$(relax show development archive)"
-  assert_success
   run relax validate "$(relax show adhoc ipa)"
-  assert_success
-  [[ "${output}" =~ "Relax Adhoc" ]]
-  [[ "${output}" =~ "J3D7L9FHSS" ]]
+
+  [[ "${lines[9]}" =~ "Bundle Version: 1.0" ]] \
+  && [[ "${lines[9]}" =~ "-debug)" ]] \
+  && [[ "${lines[11]}" =~ "com.scenee.SampleApp" ]] \
+  && [[ "${lines[31]}" =~ "Relax AdHoc" ]] \
+  && [[ "${lines[33]}" =~ "J3D7L9FHSS" ]]
+}
+
+@test "relax export adhoc <development2-archive>" {
+  run relax export adhoc "$(relax show development2 archive)"
+  run relax validate "$(relax show adhoc ipa)"
+
+  [[ "${lines[9]}" =~ "Bundle Version: 0.0.1" ]] \
+  && [[ "${lines[9]}" =~ "-debug-internal)" ]] \
+  && [[ "${lines[10]}" =~ "Bundle Name: Sample App" ]] \
+  && [[  "${lines[11]}" =~ "Bundle Identifier: com.scenee.SampleApp.debug" ]] \
+  && [[ "${lines[31]}" =~ "Relax AdHoc" ]] \
+  && [[ "${lines[33]}" =~ "J3D7L9FHSS" ]]
 }

--- a/test/parse_config.bats
+++ b/test/parse_config.bats
@@ -11,7 +11,8 @@ load test_helper
 
 	assert_success
 
-	[ "$config_xcodeproj" = "SampleApp" ]
-	[ "$config_development_scheme" = "Sample App" ]
-	[ "$config_adhoc_export_options_thinning" = "iPhone7,1" ]
+	[ "$config_xcodeproj" = "SampleApp" ] \
+	&& [ "$config_development_scheme" = "Sample App" ] \
+	&& [ "$config_adhoc_export_options_thinning" = "iPhone7,1" ]
+
 }

--- a/test/resign.bats
+++ b/test/resign.bats
@@ -15,11 +15,9 @@ load test_helper
   rm -rf *-resigned.ipa
 
   run relax resign -k relax.keychain -i "com.scenee.SampleApp" -p "Relax AdHoc" -c "iPhone Distribution: Shin Yamamoto (J3D7L9FHSS)" "$(relax show development ipa)"
-  echo "$output" >> bats.log
   assert_success
 
   run relax validate "Sample App-resigned.ipa"
-  echo "$output" >> bats.log
   assert_success
 }
 
@@ -34,7 +32,6 @@ load test_helper
 
   rm -rf *-resigned.ipa
   run relax resign -k System.keychain -i "com.scenee.SampleApp" -p "Relax AdHoc" -c "iPhone Distribution: Shin Yamamoto (J3D7L9FHSS)" "$(relax show development ipa)"
-  echo "$output" >> bats.log
   assert_failure
 
   relax keychain use relax.keychain -p relax


### PR DESCRIPTION
When a user export an ipa file from a xcarchive file, the ipa should have the same application properties(version, bundle version, bundle identifier) as ones in the xcarchive file if the user doesn't specfify any properties for the export target in Relfile.