### PR TITLE
Fix errors when an archived-expanded-entitlement.xcent is empty

### DIFF
--- a/libexec/relax-export
+++ b/libexec/relax-export
@@ -87,7 +87,6 @@ export_archive () {
 	if cat "${app_path}/$ARCHIVED_ENTITLEMENTS_XCENT" | grep -q "$team_id"; then
 		:
 	else
-		logi "$ARROW Update $ARCHIVED_ENTITLEMENTS_XCENT. IPA file will be exported in $export_path"
 		update_archived_entitlements_xcent "$team_id" "$app_path"
 	fi
 

--- a/libexec/relax-validate
+++ b/libexec/relax-validate
@@ -158,14 +158,19 @@ validate_app () {
 		logi "$ARROW Check archived-expanded-entitlements in ${app_path##*/}"
 		local xcent="$app_path/archived-expanded-entitlements.xcent"
 		if [[ -f "$xcent" ]]; then
-			local xcent_app_id=$(/usr/libexec/PlistBuddy -c "Print :application-identifier" "$xcent")
-			cat <<-EOM | logi
-			Signed entitlements: $cs_team_id.$cs_app_id
-			Archived expanded entitlements: $xcent_app_id
-			EOM
-			if [ "$cs_team_id.$cs_app_id" != "$xcent_app_id" ]; then
-				success=false
-				die "Not match the signed entitlements and the archived expanded entitlements"
+			local xcent_app_id=$(/usr/libexec/PlistBuddy -c "Print :application-identifier" \
+				"$app_path/$ARCHIVED_ENTITLEMENTS_XCENT" 2>/dev/null | grep -v "Does Not Exist")
+			if [[ -z ${xcent_app_id} ]]; then
+				logi "$WARN $ARCHIVED_ENTITLEMENTS_XCENT is empty."
+			else
+				cat <<-EOM | logi
+				Signed entitlements: $cs_team_id.$cs_app_id
+				Archived expanded entitlements: $xcent_app_id
+				EOM
+				if [ "$cs_team_id.$cs_app_id" != "$xcent_app_id" ]; then
+					success=false
+					die "Not match the signed entitlements and the archived expanded entitlements"
+				fi
 			fi
 		fi
 	fi

--- a/libexec/util-build
+++ b/libexec/util-build
@@ -667,7 +667,13 @@ update_archived_entitlements_xcent () {
 	#codesign -dv "${app_path}" 2>&1 | grep -e "Format\|Identifier\|Signed Time" > $REL_TEMP_DIR/codesign_info
 	#local cs_team_id=$(cat $REL_TEMP_DIR/codesign_info | sed -ne "s/TeamIdentifier=\(.*\)/\1/p")
 
-	local app_id=$(/usr/libexec/PlistBuddy -c "Print :application-identifier" "$app_path/$ARCHIVED_ENTITLEMENTS_XCENT")
+	local app_id=$(/usr/libexec/PlistBuddy -c "Print :application-identifier" "$app_path/$ARCHIVED_ENTITLEMENTS_XCENT" 2>/dev/null | grep -v "Does Not Exist")
+	if [[ -z ${app_id} ]]; then
+		logi "$WARN $ARCHIVED_ENTITLEMENTS_XCENT is empty."
+		return
+	fi
+
+	logi "$ARROW Update $ARCHIVED_ENTITLEMENTS_XCENT. IPA file will be exported in $export_path"
 	_src_team=${app_id%%.*}
 
 	cp "$app_path/$ARCHIVED_ENTITLEMENTS_XCENT" "$_entitlements_xcent"


### PR DESCRIPTION
I encountered a case when an archived-expanded-entitlemnt.xcent file is
an empty plist. Relax stopped operations when it handled the file. So I
add escapes in the case.