### PR TITLE
util-build: Fix __check_scheme()

### DIFF
--- a/libexec/util-build
+++ b/libexec/util-build
@@ -222,12 +222,25 @@ __map_vals () {
 }
 
 
-# __check_scheme <scheme>
+# __check_scheme <params> <scheme>
 __check_scheme () {
-	if find ./*.xcodeproj -name "$1".xcscheme |  grep '.*' > /dev/null; then
+	local build_params
+	__setup_build_params
+
+	#if find ./ -name "$1".xcscheme |  grep '.*' > /dev/null; then
+	if xcodebuild "${build_params[@]}" -list | sed -n '/Schemes/,$ p' | grep "$1" > /dev/null; then
 		:
 	else
 		die "Not found '$1' scheme in your project. You might need to make it shared by checking 'Shared' box"
+	fi
+}
+
+# Update global/local 'build_params' variable
+__setup_build_params () {
+	if [[ ${REL_CONFIG_workspace-undefined} != "undefined" ]]; then
+		build_params=( -workspace "$REL_CONFIG_workspace.xcworkspace" )
+	else
+		build_params=( -project "$REL_CONFIG_xcodeproj.xcodeproj" )
 	fi
 }
 
@@ -246,33 +259,29 @@ __replace_development_team () {
 
 # get_build_base_params <scheme> [buildsettings=value] ...
 get_build_params_file () {
-	local scheme params xcode_build_params
+	local scheme build_params xcode_build_params
 	scheme="$1"
 	shift
 
 	xcode_build_params=$REL_TEMP_DIR/xcode_build_params
 	rm -rf $xcode_build_params
 
-	if [[ ${REL_CONFIG_workspace-undefined} != "undefined" ]]; then
-		params=( -workspace "$REL_CONFIG_workspace.xcworkspace" )
-	else
-		params=( -project "$REL_CONFIG_xcodeproj.xcodeproj" )
-	fi
+	__setup_build_params
 
-	params+=(-scheme "${scheme}")
+	build_params+=(-scheme "${scheme}")
 
 	if test $# -gt 0; then
 		for arg in "$@"
 		do
-			params+=( "$arg" )
+			build_params+=( "$arg" )
 		done
 	fi
 	
-	[[ ${params[@]} =~ "-configuration" ]] || [[ -z $configuration ]] ||\
-		params+=( -configuration "$configuration" )
+	[[ ${build_params[@]} =~ "-configuration" ]] || [[ -z $configuration ]] ||\
+		build_params+=( -configuration "$configuration" )
 
 	if [[ -n $provisioning_profile ]]; then
-		params+=( PROVISIONING_PROFILE_SPECIFIER="$provisioning_profile" )
+		build_params+=( PROVISIONING_PROFILE_SPECIFIER="$provisioning_profile" )
 		local mobileprovision=$(find_mobileprovision "$provisioning_profile")
 		[[ -n $mobileprovision ]] || die "Not found '$provisioning_profile' provisoning profile"
 
@@ -281,19 +290,15 @@ get_build_params_file () {
 		# But it's not working when exporint ana adhoc IPA file.
 		# I confirmed It's working well in Xcode 7.3.1.
 		if [[ "$(__is_distribution_profile "$mobileprovision")" = true ]]; then
-			params+=( CODE_SIGN_IDENTITY="iPhone Distribution" )
+			build_params+=( CODE_SIGN_IDENTITY="iPhone Distribution" )
 		else
-			params+=( CODE_SIGN_IDENTITY="iPhone Developer" )
+			build_params+=( CODE_SIGN_IDENTITY="iPhone Developer" )
 		fi
 	else
-		params+=( CODE_SIGN_IDENTITY="iPhone Developer" )
+		build_params+=( CODE_SIGN_IDENTITY="iPhone Developer" )
 	fi
 
-	if [[ -n $team_id ]]; then
-		param+=( DEVELOPMENT_TEAM="$team_id" )
-	fi
-
-	params+=( ONLY_ACTIVE_ARCH=NO )
+	build_params+=( ONLY_ACTIVE_ARCH=NO )
 
 
 	if test "${build_settings:-undefined}" != undefined; then
@@ -304,7 +309,7 @@ get_build_params_file () {
 		fi
 	fi
 
-	for e in "${params[@]}"
+	for e in "${build_params[@]}"
 	do
 		echo "$e" >> $xcode_build_params
 	done
@@ -697,7 +702,7 @@ update_archived_entitlements_xcent () {
 
 declare -x -f print_progress_time progress_bar
 declare -x -f __kill_bg_xcodebuid_task
-declare -x -f __check_scheme __map_vals __replace_development_team
+declare -x -f __check_scheme __map_vals __replace_development_team __setup_build_params
 declare -x -f load_xcode_build_settings get_build_params_file
 declare -x -f print_info_plist print_xcode_version
 declare -x -f setup_build teardown_build

--- a/libexec/util-config
+++ b/libexec/util-config
@@ -51,7 +51,7 @@ config_collect_releases () {
 _check_config () {
 	if [[ "${REL_CONFIG_xcodeproj:-undefined}" = undefined ]]; then
 		if [[ "${REL_CONFIG_workspace:-undefined}" = undefined ]]; then
-			die "Please configure XCODEPROJ or WORKSPACE in config file."
+			die "Please configure 'xcodeproj:' or 'workspace:' field on the top of config file."
 		fi
 	fi
 


### PR DESCRIPTION
Fix `__check_scheme()` logic to support a subproject not existing in a root directory.