### PR TITLE
archive: Add '--no-cache' option

### DIFF
--- a/libexec/relax
+++ b/libexec/relax
@@ -54,8 +54,8 @@ usage () {
 	Usage: ${ME} [option] <command|module> ...
 
 	Options:
-	    -v		: Be verbose when executing commands
-	    -h		: Show help
+	    -v		Be verbose when executing commands
+	    -h		Show help
 
 	Commands:
 	    init	Set up $ME 

--- a/libexec/relax-archive
+++ b/libexec/relax-archive
@@ -4,7 +4,12 @@
 
 usage () {
 	cat <<-EOM
-	usage: ${ME} archive <release> [-c <configuration>] [<xcodebuild-option>] ...
+	Usage: ${ME} archive <release> [-c <configuration>] [<xcodebuild-option>] ...
+
+	Options:
+	    --no-cache	Remove a DerivedData of the schema
+	    -c		Specify a configuration
+	
 	EOM
 	fin
 }
@@ -49,10 +54,12 @@ make_archive () {
 		cp "$XCSCHEME_PATH" "$PRODUCT_BUILD_ROOT/${XCSCHEME_PATH##/*}"
 	fi
 
-	if [[ $OBJROOT =~ .*DerivedData.* ]] && [ -d "$OBJROOT" ]; then
-		logi "$ARROW Clean DerivedData of $TARGETNAME"
-		rm -rf $OBJROOT
-		logi "Removed $OBJROOT"
+	if [[ $no_cache == true ]]; then
+		if [[ $OBJROOT =~ .*DerivedData.* ]] && [ -d "$OBJROOT" ]; then
+			logi "$ARROW Clean DerivedData of $TARGETNAME"
+			rm -rf $OBJROOT
+			logi "Removed $OBJROOT"
+		fi
 	fi
 
 	logi "$ARROW Archiving $scheme ($configuration) for $sdk SDK"
@@ -115,6 +122,7 @@ make_archive () {
 XCSCHEME_PATH=
 
 release=
+no_cache=false
 
 while [ $# -ne 0 ];
 do
@@ -135,6 +143,9 @@ do
 		[[ $# != 0 ]] || usage
 		configuration=$1
 		shift
+		;;
+	--no-cache)
+		no_cache=true
 		;;
 	*)
 		release=$arg

--- a/test/archive.bats
+++ b/test/archive.bats
@@ -13,5 +13,13 @@ load test_helper
   export VERSION="0.0.1"
   run  relax archive development2
   assert_success
+  [[ ! "${output}" =~ "Clean DerivedData" ]]
 }
 
+@test "relax archive --no-cache development2" {
+  export BUNDLE_SUFFIX=debug
+  export VERSION="0.0.1"
+  run  relax archive --no-cache development2
+  assert_success
+  [[ "${output}" =~ "Clean DerivedData" ]]
+}


### PR DESCRIPTION
To improve a performance of `archive`,  I add `--no-cache` option to make it optional to delete a derived data of Xcode

The derived data files of Xcode can cause a build error, but it can make it fast to build an archive. It's trade off.

However it's not good idea to force deleting them. It's better to have a range of choice in the issue.
