### PR TITLE
util: Fix a hang(wait for stdin) in die() on bamboo

### DIFF
--- a/libexec/relax-package
+++ b/libexec/relax-package
@@ -22,8 +22,14 @@ make_package() {
 
 	logi "$ARROW Clean up $package_dir"
 	{
-		rm -rf "$package_dir"
-		mkdir -p "$temp_dir"
+	mkdir -p "$temp_dir"
+	rm -rf "$package_dir"
+	if grep -q "/" <<< "$package_dir"; then
+		local package_parent_dir="${package_dir%/*}"
+		if [[ ! -d "$package_parent_dir" ]]; then
+			mkdir -p "$package_parent_dir"
+		fi
+	fi
 	} > /dev/null 2>&1
 	
 
@@ -43,6 +49,8 @@ make_package() {
 		logi "$WARN Not found '$distribution' archive"
 	fi
 
+	echo $package_dir
+	echo $temp_dir
 	cp -a "$temp_dir" "$package_dir"
 	logi "Package Directory: $HERE/$package_dir"
 	ls "$package_dir"

--- a/libexec/util
+++ b/libexec/util
@@ -78,7 +78,7 @@ teardown () {
 }
 
 fin () {
-	if [ $# -gt 0 ]; then
+	if [[ $# -gt 0 ]]; then
 		echo -e "$@"
 	elif [[ -p /dev/stdin ]]; then
 		echo -e "$(</dev/stdin)"
@@ -87,10 +87,10 @@ fin () {
 }
 
 die () {
-	if [[ -p /dev/stdin ]]; then
-		die_with_status 1 "$(</dev/stdin)"
-	else
+	if [[ $# -gt 0 ]]; then
 		die_with_status 1 "$@"
+	elif [[ -p /dev/stdin ]]; then
+		die_with_status 1 "$(</dev/stdin)"
 	fi
 }
 


### PR DESCRIPTION
Bamboo should open stdin when it executes a job. Relax die() could try to read the empty stream and waiting for a data. I fixed the problem.