### PR TITLE
util-build: No more cache old build artifacts

### DIFF
--- a/libexec/const
+++ b/libexec/const
@@ -2,7 +2,7 @@
 # @(#) relax: constants
 
 export REL_CONFIG="Relfile"
-export REL_RELEASE_ROOT="Releases"
+export REL_RELEASE_ROOT="dists"
 export REL_DATA_DIR=".relax"
 export REL_TEMP_ROOT="$( [[ ${TMPDIR:-undefined} != undefined ]] && echo "$TMPDIR/$ME" || echo "/tmp/$ME" )"
 export REL_CACHE_DIR="$HOME/$REL_DATA_DIR/caches"

--- a/libexec/relax-archive
+++ b/libexec/relax-archive
@@ -117,7 +117,6 @@ make_archive () {
 	fi
 
 	logi "$ARROW $archive_path"
-	ln -fs "$archive_path" "$LATEST_ARCHIVE"
 }
 
 XCSCHEME_PATH=
@@ -165,7 +164,5 @@ setup_build $distribution
 
 data_root=$REL_RELEASE_ROOT/$distribution/$REL_DATA_DIR
 mkdir -p "$data_root"
-
-LATEST_ARCHIVE="$data_root/LATEST_ARCHIVE"
 
 make_archive "$PRODUCT_BUILD_ROOT/$PRODUCT_NAME.xcarchive" "$@"

--- a/libexec/relax-export
+++ b/libexec/relax-export
@@ -163,19 +163,11 @@ export_archive () {
 	else
 		logi "$ARROW $ipa_path"
 	fi
-
-	# update a symbolic link of the latest archive
-	rm -f "$LATEST_IPA"
-	ln -fs "$ipa_path" "$LATEST_IPA"
-	rm -f "$LATEST_EXPORT_DIR"
-	ln -fs "$export_path" "$LATEST_EXPORT_DIR"
 }
 
 prepare_export() {
 	local data_root="$REL_RELEASE_ROOT/$distribution/$REL_DATA_DIR"
 	mkdir -p "$data_root"
-	LATEST_IPA="$data_root/LATEST_IPA"
-	LATEST_EXPORT_DIR="$data_root/LATEST_EXPORT_DIR"
 	EXPORT_OPTIONS_PLIST=$REL_TEMP_DIR/ExportOptions.plist
 }
 

--- a/libexec/util-build
+++ b/libexec/util-build
@@ -25,23 +25,24 @@ read_path () {
 	local release=$1
 	local type=$2
 
-	local data_root=$REL_RELEASE_ROOT/$release/$REL_DATA_DIR
+	local data_root=$REL_RELEASE_ROOT/$release
 
-	local link_path=""
+	local path=""
 	case $type in
 	ipa)
-		link_path=$data_root/LATEST_IPA
+		path="$(find "$data_root" -depth 1 -name "*.ipa")"
 		;;
 	build)
-		link_path=$data_root/LATEST_EXPORT_DIR
+		path=$data_root
 		;;
 	archive)
-		link_path=$data_root/LATEST_ARCHIVE
+		path="$(find "$data_root" -name "*.xcarchive" -depth 1)"
 		;;
 	esac
 
-	test -L "$link_path" || return 1
-	readlink "$link_path"
+	if [[ -n "$path" ]]; then
+		echo "$path"
+	fi
 }
 
 
@@ -540,7 +541,6 @@ setup_build () {
 		die "This scheme($scheme) isn't for an Application, Framework or Library target"
 	fi
 
-
 	logi "$ARROW Set up '$release' configurations"
 	logi "Configuration: $CONFIGURATION"
 	configuration=$CONFIGURATION
@@ -549,7 +549,7 @@ setup_build () {
 
 	# StaticLibrary doesn't have a Info.plist
 	if [ -z $INFO_PLIST_PATH ]; then
-		PRODUCT_BUILD_ROOT="$REL_RELEASE_ROOT/$release/$scheme"
+		PRODUCT_BUILD_ROOT="$REL_RELEASE_ROOT/$release"
 		logi "Build Root: $PRODUCT_BUILD_ROOT"
 		mkdir -p "$PRODUCT_BUILD_ROOT"
 		return
@@ -674,10 +674,7 @@ setup_build () {
 		BUNDLE_VERSION="${BASH_REMATCH[1]}${CURRENT_PROJECT_VERSION}${BASH_REMATCH[2]}"
 	fi
 	
-	if [[ $for_export == false ]] && ! echo $BUNDLE_VERSION  | grep -iqF $configuration;  then
-		BUNDLE_VERSION=$BUNDLE_VERSION-$configuration
-	fi
-	PRODUCT_BUILD_ROOT=$(eval echo "$REL_RELEASE_ROOT/$release/$scheme-$BUNDLE_VERSION")
+	PRODUCT_BUILD_ROOT=$(eval echo "$REL_RELEASE_ROOT/$release")
 	logi "Build Root: $PRODUCT_BUILD_ROOT"
 	mkdir -p "$PRODUCT_BUILD_ROOT"
 }


### PR DESCRIPTION
Actually I can't find any use case to remain old build artifacts, I guess it might be though.
In spite of that, old build artifacts eclipse disk memory on every build. It's too bad.
