### PR TITLE
Disable 'build_options' field in distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,6 @@ distributions:  # Define a distribution
         - "-DDEBUG" 
       OTHER_C_FLAGS:
         - "-fsanitize=address"
-    build_options:
-      enableAddressSanitizer: true
-      enableThreadSanitizer: true
-      enableUndefinedBehaviorSanitizer: true
     export_options:
       method:  ad-hoc
       compileBitcode: false

--- a/libexec/relax-archive
+++ b/libexec/relax-archive
@@ -72,7 +72,9 @@ make_archive () {
 	local params_file=$(get_build_params_file "$scheme" -sdk "$sdk" -archivePath "$archive_path")
 
 	while read p; do params+=( "$p" ); done < $params_file
-	while read p; do params+=( "$p" ); done < <(relparser -f "$REL_CONFIG_PATH" build_options "$distribution")
+
+	## Disable 'build_options' because `-enable{Address,Thread}Sanitizer` options don't work on 'xcodebuild archive'
+	# while read p; do params+=( "$p" ); done < <(relparser -f "$REL_CONFIG_PATH" build_options "$distribution")
 
 	# See https://developer.apple.com/library/content/technotes/tn2215/_index.html
 	params+=(INSTALL_PATH="\$(LOCAL_APPS_DIR)")

--- a/libexec/relax-build
+++ b/libexec/relax-build
@@ -30,7 +30,9 @@ build_project () {
 	local params_file=$(get_build_params_file "$scheme" -sdk "$_sdk" -configuration "${_configuration}")
 
 	while read p; do params+=( "$p" ); done < $params_file
-	while read p; do params+=( "$p" ); done < <(relparser -f "$REL_CONFIG_PATH" build_options "$Distribution")
+
+	## Disable 'build_options' because `-enable{Address,Thread}Sanitizer` options don't work on 'xcodebuild archive'
+	# while read p; do params+=( "$p" ); done < <(relparser -f "$REL_CONFIG_PATH" build_options "$Distribution")
 
 	local build_suffix=$(echo "${_configuration}-${_sdk}")
 	local build_settings_file="$PRODUCT_BUILD_ROOT/$build_suffix.settings"

--- a/sample/Relfile
+++ b/sample/Relfile
@@ -37,12 +37,6 @@ distributions:
       OTHER_LINKER_FLAGS:
         - "$(inherited)"
         - "-ObjC"
-    build_options:
-      enableAddressSanitizer: true
-      enableThreadSanitizer: true
-      enableUndefinedBehaviorSanitizer: true
-      # toolchain: <toolchain_name>
-      # xcconfig: <xcconfig_path>
     export_options:
       method: development # Required
       compileBitcode: false

--- a/test/relparser.bats
+++ b/test/relparser.bats
@@ -27,21 +27,21 @@ source libexec/util-build
 	&& [ "$(/usr/libexec/PlistBuddy  -c "Print :uploadBitcode" $TMPDIR/options.plist)" == "true" ] 
 }
 
-@test "relparser build_options" {
-	run $LIBEXEC_PATH/relparser build_options development
-	assert_success
-
-	if is_xcode_version ">=" 9; then
-		[[ "${lines[0]}"  == "-enableAddressSanitizer" ]] \
-		&& [[ "${lines[1]}" == "YES" ]] \
-		&& [[ "${lines[2]}" == "-enableThreadSanitizer" ]] \
-		&& [[ "${lines[3]}" == "YES" ]] \
-		&& [[ "${lines[4]}" == "-enableUndefinedBehaviorSanitizer" ]] \
-		&& [[ "${lines[5]}" == "YES" ]]
-	else
-		[[ "${lines[0]}"  == "-enableAddressSanitizer" ]] \
-		&& [[ "${lines[1]}" == "YES" ]] \
-		&& [[ "${lines[2]}" == "-enableThreadSanitizer" ]] \
-		&& [[ "${lines[3]}" == "YES" ]]
-	fi
-}
+#@test "relparser build_options" {
+#	run $LIBEXEC_PATH/relparser build_options development
+#	assert_success
+#
+#	if is_xcode_version ">=" 9; then
+#		[[ "${lines[0]}"  == "-enableAddressSanitizer" ]] \
+#		&& [[ "${lines[1]}" == "YES" ]] \
+#		&& [[ "${lines[2]}" == "-enableThreadSanitizer" ]] \
+#		&& [[ "${lines[3]}" == "YES" ]] \
+#		&& [[ "${lines[4]}" == "-enableUndefinedBehaviorSanitizer" ]] \
+#		&& [[ "${lines[5]}" == "YES" ]]
+#	else
+#		[[ "${lines[0]}"  == "-enableAddressSanitizer" ]] \
+#		&& [[ "${lines[1]}" == "YES" ]] \
+#		&& [[ "${lines[2]}" == "-enableThreadSanitizer" ]] \
+#		&& [[ "${lines[3]}" == "YES" ]]
+#	fi
+#}


### PR DESCRIPTION
This is because `-enable{Address,Thread}Sanitizer` don't work on
`xcodebuild archive`. They work well on `xcodebuild build`.