### PR TITLE
export: Fix an exit on 'relparser/relfile.getBundleID'

### DIFF
--- a/libexec/relax-export
+++ b/libexec/relax-export
@@ -79,17 +79,17 @@ export_archive () {
 	logi "$ARROW Exporting $1"
 
 	local export_path="${PRODUCT_BUILD_ROOT}"
-
-
 	local archive_path="$REL_TEMP_DIR/xcarchive"
 	cp -a "$1" "$archive_path"
 
 	local app_path="$(find "$archive_path" -name *.app)";
 
 	if [[ $use_packageapp == false ]]; then
+		local raw_info_plist="$REL_TEMP_DIR/Info.plist";
+		plutil -convert xml1 -o "$raw_info_plist" "$app_path/Info.plist"
 		relparser -f "$REL_CONFIG_PATH" \
 			-o "$EXPORT_OPTIONS_PLIST" \
-			-plist "$archive_path/Info.plist"  \
+			-plist "$raw_info_plist"  \
 			export_options $distribution
 		cat $EXPORT_OPTIONS_PLIST
 		printf "\n"


### PR DESCRIPTION
An Info.plist in archive file can't include  'ApplicationProperties' key values so that it cause this error

```
goroutine 1 [running]:
relparser/relfile.getBundleID(0x7fff5fbf8394, 0x53, 0x0, 0x0)
        /Users/shin/Workspace/scenee/relax/go/src/relparser/relfile/distribution.go:69 +0x2de
relparser/relfile.Distribution.writeExportOptions(0x0, 0x0, 0xc420016bc0, 0xb, 0xc420016c00, 0xa, 0xc420016bcb, 0x5, 0x0, 0x0, ...)
        /Users/shin/Workspace/scenee/relax/go/src/relparser/relfile/distribution.go:121 +0x236
relparser/relfile.Relfile.GenOptionsPlist(0xc420016b1f, 0x1, 0xc420016b60, 0xb, 0x0, 0x0, 0x0, 0xc420016b88, 0x8, 0xc42001b8c0, ...)
        /Users/shin/Workspace/scenee/relax/go/src/relparser/relfile/relfile.go:91 +0x15a
main.main()
        /Users/shin/Workspace/scenee/relax/go/src/relparser/relparser.go:88 +0x629
```