### PR TITLE
Fix archived-expanded-entitlements.xcent error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
       osx_image: xcode9
     - os: osx
       osx_image: xcode9.2
+    - os: osx
+      osx_image: xcode9.3
 
 script:
   - test/travis_ci.sh

--- a/libexec/util-build
+++ b/libexec/util-build
@@ -719,6 +719,10 @@ update_archived_entitlements_xcent () {
 	local _app_path=$2
 	local _entitlements_xcent=$REL_TEMP_DIR/entitlements_xcent
 
+	if [[ ! -f "$app_path/$ARCHIVED_ENTITLEMENTS_XCENT" ]]; then
+		return
+	fi
+
 	#codesign -dv "${app_path}" 2>&1 | grep -e "Format\|Identifier\|Signed Time" > $REL_TEMP_DIR/codesign_info
 	#local cs_team_id=$(cat $REL_TEMP_DIR/codesign_info | sed -ne "s/TeamIdentifier=\(.*\)/\1/p")
 


### PR DESCRIPTION
The error is here.
    cp: /path/to/archived-expanded-entitlements.xcent: No such file or directory

Xcode 9.3 doesn't seems to generate archived-expanded-entitlements.xcent file.