### PR TITLE
go/relparser: Fix random build errors

### DIFF
--- a/go/src/relparser/relfile/distribution.go
+++ b/go/src/relparser/relfile/distribution.go
@@ -50,7 +50,7 @@ func (d *Distribution) UnmarshalYAML(unmarshal func(interface{}) error) (err err
 
 func (d *Distribution) Check() {
 	// Check the ProvisioningProfile existence
-	infos := FindProvisioningProfile(d.ProvisioningProfile, "")
+	infos := FindProvisioningProfile("^"+d.ProvisioningProfile+"$", "")
 	if len(infos) == 0 {
 		logger.Fatalf("\"%s\" not found.", d.ProvisioningProfile)
 	}
@@ -181,29 +181,28 @@ func (d Distribution) writeSource(name string, out *os.File) {
 	)
 
 	source += fmt.Sprintf("export %v=\"%v\"\n", "_SCHEME", d.Scheme)
+
 	source += fmt.Sprintf("export %v=\"%v\"\n", "_SDK", d.Sdk)
 	source += fmt.Sprintf("export %v=\"%v\"\n", "_CONFIGURATION", d.Configuration)
-	source += fmt.Sprintf("export %v=\"%v\"\n", "_PROVISIONING_PROFILE", d.ProvisioningProfile)
 
 	source += fmt.Sprintf("export %v=\"%v\"\n", "_VERSION", d.Version)
 	source += fmt.Sprintf("export %v=\"%v\"\n", "_BUNDLE_ID", d.BundleID)
 	source += fmt.Sprintf("export %v=\"%v\"\n", "_BUNDLE_VERSION", d.BundleVersion)
 
-	infos := FindProvisioningProfile(d.ProvisioningProfile, "")
-
+	infos := FindProvisioningProfile("^"+d.ProvisioningProfile+"$", "")
 	if len(infos) == 0 {
 		logger.Fatalf("Not installed \"%s\"", d.ProvisioningProfile)
 	}
 
 	pp := infos[0].Pp
+	source += fmt.Sprintf("export %v=\"%v\"\n", "_PROVISIONING_PROFILE", pp.Name)
 	source += fmt.Sprintf("export %v=\"%v\"\n", "_TEAM_ID", pp.TeamID())
 	source += fmt.Sprintf("export %v=\"%v\"\n", "_IDENTITY", pp.CertificateType())
-	// fmt/Println("--- Build settings\n")
-	build_settings = strings.Join([]string{PREFIX, name, "build_settings"}, "_")
-
-	source += fmt.Sprintf("%v=()\n", build_settings)
 
 	// FIXME: Improve here
+	// Build Settings
+	build_settings = strings.Join([]string{PREFIX, name, "build_settings"}, "_")
+	source += fmt.Sprintf("%v=()\n", build_settings)
 	for k, v := range d.BuildSettings {
 		switch v := v.(type) {
 		case []interface{}:

--- a/go/src/relparser/relfile/distribution.go
+++ b/go/src/relparser/relfile/distribution.go
@@ -190,14 +190,12 @@ func (d Distribution) writeSource(name string, out *os.File) {
 	source += fmt.Sprintf("export %v=\"%v\"\n", "_BUNDLE_VERSION", d.BundleVersion)
 
 	infos := FindProvisioningProfile("^"+d.ProvisioningProfile+"$", "")
-	if len(infos) == 0 {
-		logger.Fatalf("Not installed \"%s\"", d.ProvisioningProfile)
+	if len(infos) > 0 {
+		pp := infos[0].Pp
+		source += fmt.Sprintf("export %v=\"%v\"\n", "_PROVISIONING_PROFILE", pp.Name)
+		source += fmt.Sprintf("export %v=\"%v\"\n", "_TEAM_ID", pp.TeamID())
+		source += fmt.Sprintf("export %v=\"%v\"\n", "_IDENTITY", pp.CertificateType())
 	}
-
-	pp := infos[0].Pp
-	source += fmt.Sprintf("export %v=\"%v\"\n", "_PROVISIONING_PROFILE", pp.Name)
-	source += fmt.Sprintf("export %v=\"%v\"\n", "_TEAM_ID", pp.TeamID())
-	source += fmt.Sprintf("export %v=\"%v\"\n", "_IDENTITY", pp.CertificateType())
 
 	// FIXME: Improve here
 	// Build Settings

--- a/libexec/util-build
+++ b/libexec/util-build
@@ -269,15 +269,17 @@ get_build_params_file () {
 
 	build_params+=( ONLY_ACTIVE_ARCH=NO DEBUG_INFORMATION_FORMAT=dwarf-with-dsym )
 
-	if is_xcode_version ">=" 8; then
-		build_params+=( PROVISIONING_PROFILE_SPECIFIER="$_PROVISIONING_PROFILE" )
-	fi
+	if [[ ${_PROVISIONING_PROFILE:-undefined} != undefined ]]; then
+		if is_xcode_version ">=" 8; then
+			build_params+=( PROVISIONING_PROFILE_SPECIFIER="$_PROVISIONING_PROFILE" )
+		fi
 
-	if is_xcode_version ">=" 9; then
-		build_params+=( CODE_SIGN_STYLE="Manual" )
-	fi
+		if is_xcode_version ">=" 9; then
+			build_params+=( CODE_SIGN_STYLE="Manual" )
+		fi
 
-	build_params+=( CODE_SIGN_IDENTITY="$_IDENTITY" )
+		build_params+=( CODE_SIGN_IDENTITY="$_IDENTITY" )
+	fi
 
 	if test "${_BUILD_SETTINGS:-undefined}" != undefined; then
 		if test ${#_BUILD_SETTINGS[@]} -gt 0; then
@@ -522,6 +524,10 @@ setup_build () {
 		fi
 		# Team ID
 		logi "Team ID: $_TEAM_ID"
+	else
+		if [[ ${_PROVISIONING_PROFILE:-undefined} != undefined ]]; then
+			logw "Ignored 'provisioning_profile' field in Relfile because it's not needed for a library/framework build"
+		fi
 	fi
 
 	logv "Info plist: $INFO_PLIST_PATH"


### PR DESCRIPTION
The error can happen when there are provisioning profile including the
same keyword like 'Relax Enterprise' and 'Relax Enterprise (Development)'.